### PR TITLE
Updating to support crystal 0.14.1

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -86,7 +86,7 @@ module Config
       return value
     end
 
-    protected def _build_index(data : ::Hash, root = "" : String)
+    protected def _build_index(data : ::Hash, root : String = "")
       index = {} of String => Val
       data.keys.each do |key|
         value = data[key]

--- a/src/yaml.cr
+++ b/src/yaml.cr
@@ -11,10 +11,8 @@ module Config
         raise ArgumentError.new("invalid file '#{file}'")
       end
 
-      data = ::YAML.load(File.open(file).gets_to_end)
-      if (!data)
-        data = ::Hash(String, ::YAML::Type).new
-      end
+      data = ::YAML.parse(File.open(file).gets_to_end)
+      data = data ? data.as_h : (::Hash(String, ::YAML::Type).new)
 
       @filename = file
 


### PR DESCRIPTION
This is a fix for two changes:
- now the default value should be set after the type annotation
- `YAML.load` now is `YAML.parse` and return `Hash(String, YAML::Any)`, but it can be converted to `Hash(String, YAML::Type)` using `.to_h`
